### PR TITLE
Change grid-column-end to -1 for sponsor footer

### DIFF
--- a/src/_includes/sponsor-footer.njk
+++ b/src/_includes/sponsor-footer.njk
@@ -4,7 +4,7 @@
 	background-color: #fff;
 	padding: .5rem;
 	grid-column-start: 1;
-	grid-column-end: last;
+	grid-column-end: -1;
   width: 100%;
 	max-width: 100%;
 }


### PR DESCRIPTION
I copied the `#sponsor-footer` html and styles into my static copy just to see what it will ultimately look like. It ended up breaking the grid I have set on `<body>`. Since that markup and styling isn’t included with the download, I think this change will help alleviate this problem in the future.

This PR changes `grid-column-end: last;` to `grid-column-end: -1;` for the `#sponsor-footer`.

This keeps it from breaking the layout if `<body>` has `display: grid;` and does not require submissions to explicitly name the grid lines.