### PR TITLE
fixed the sponsor-footer section

### DIFF
--- a/src/styles/css/propaganda.css
+++ b/src/styles/css/propaganda.css
@@ -323,7 +323,7 @@ aside {
 @media (max-width: 800px) {
   aside {
     width: calc(100% - 4rem);
-    margin: auto 2rem;
+    margin: auto;
   }
 }
 @media (max-width: 1024px) {


### PR DESCRIPTION
Hello,

I was looking at all these amazing styles contributors made, and i found by accident that there is a small issue with mobile responsiveness for the Propaganda style.

![Annotation 2020-07-29 202953](https://user-images.githubusercontent.com/49839827/88844626-d5e74280-d1da-11ea-8b14-9251135c01bf.png)


fixed the #sponsor-footer section to be responsive on mobile view

### New Stylesheet Submissions:

<!-- Please title your pull request with your stylesheet's name -->

<!-- IMPORTANT: If you forked this project prior to July 19, the format has changed and your commit should now be a single .json file located inside of `src/_data/styles.json`. For best results, make sure your fork is up-to-date and then create your .json file before opening your PR -->

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other files using the same name as yours?
- [ ] Have you filled in at least the required data for `title`, `author`, and `stylesheet`?
- [ ] Is the value of `stylesheet` a full URL that is publicly accessible and renders a compiled CSS file?

<!-- Add any additional notes below -->
