### PR TITLE
Fix small typo in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 <!-- Please title your pull request with your stylesheet's name -->
 
-<!-- IMPORTANT: If you forked this project prior to July 19, the format has changed and your commit should now be a single .json file located inside of `src/_data/styles.json`. For best results, make sure your fork is up-to-date and then create your .json file before opening your PR -->
+<!-- IMPORTANT: If you forked this project prior to July 19, the format has changed and your commit should now be a single .json file located inside of `src/_data/styles`. For best results, make sure your fork is up-to-date and then create your .json file before opening your PR -->
 
 - [ ] Have you followed the guidelines in our Contributing document?
 - [ ] Have you checked to ensure there aren't other files using the same name as yours?


### PR DESCRIPTION
Fixes a small typo in the PR template. `src/_data/styles` is a directory, not a JSON file.