### PR TITLE
Create styles-must-go-on.json

### DIFF
--- a/src/_data/styles/styles-must-go-on.json
+++ b/src/_data/styles/styles-must-go-on.json
@@ -1,0 +1,8 @@
+{
+  "title": "The Styles Must Go On!",
+  "author": "Joe Lamyman",
+  "stylesheet": "https://joelamyman.co.uk/stylestage/style.css",
+  "twitter": "JoeLamyman",
+  "websiteTitle": "Joe Lamyman's Portfolio",
+  "websiteUrl": "https://joelamyman.co.uk/"
+}


### PR DESCRIPTION
### New Stylesheet Submission:

<!-- 🚨 Please title your pull request with your stylesheet's name -->

<!-- IMPORTANT: If you forked this project prior to July 19, the format has changed and your commit should now be a single .json file located inside of `src/_data/styles`. For best results, make sure your fork is up-to-date and then create your .json file before opening your PR -->

<!-- ✅ To answer yes on the following, update [] to [x]. You will get faster approval if all these conditions are met! -->

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other files using the same name as yours?
- [x] Have you filled in at least the required data for `title`, `author`, and `stylesheet`?
- [x] Is the value of `stylesheet` a full URL that is publicly accessible and renders an unminified, compiled CSS file?
- [x] Do your styles pass proper contrast for accessibility?
- [x] Have you included `@media (prefers-reduced-motion: reduce)` to remove animations on `*,*::before,*::after`?
- [x] Did you style the `.skip-link`?
- [x] Have you checked on a real mobile device to ensure your responsive design doesn't cause overlaps or overflow scrolling?

<!-- 📝 Add any additional notes below -->

Hi there!

I've tested my design with the axe extension within Google Chrome on Mac. It returns 6 color contrast issues, when the text is essentially white on a black background. Testing the contrast with WebAIM provides a result of a 10.44:1 contrast and Chrome reveals the same. I think this may be a false positive produced by axe in this instance? Alternatively, I may have completely misunderstood, so please let me know if there's anything that needs improving!

The design relies heavily on animation, so using reduced motion at the bottom of my stylesheet, I've provided a static version.

Attached is a screenshot of axe showing one of the elements that it believes to have contrast issues. The following screenshot is Chrome showing that it actually passes as described earlier.

![Screenshot 2021-01-09 at 19 20 23](https://user-images.githubusercontent.com/31854295/104106852-5b097400-52b0-11eb-97f6-0a05d3dc9070.png)

![Screenshot 2021-01-09 at 19 20 06](https://user-images.githubusercontent.com/31854295/104106856-5e9cfb00-52b0-11eb-9ac2-23180a3e226d.png)

