### PR TITLE
fix: abandoned stage stylesheet link fix

### DIFF
--- a/src/_data/styles/abandoned-stage.json
+++ b/src/_data/styles/abandoned-stage.json
@@ -1,0 +1,8 @@
+{
+  "title": "Abandoned Stage",
+  "author": "Andrey Kudryavtsev",
+  "stylesheet": "https://raw.githubusercontent.com/cat-street/cat-street/main/abandonedstage.css",
+  "twitter": "cat__logic",
+  "websiteTitle": "catlogic.ru",
+  "websiteUrl": "https://catlogic.ru"
+}


### PR DESCRIPTION

Provided the correct link to my previous submission's CSS file, 'Abandoned Stage' (the previous file was carelessly removed with unused repository).
The contents of the CSS file has not been modified since the previous submission.